### PR TITLE
Add element of randomness in words chosen for incdec()

### DIFF
--- a/R/incdec.R
+++ b/R/incdec.R
@@ -1,16 +1,23 @@
 # incdec
 #
-#' Returns a character string that quantifies a change.
+#' Returns a character string that quantifies a change, randomly choosing from a
+#' set of words to describe the change.
 #
 #' @param value value to be quantified
 #' @param tense which tense you want the quantifying string to be in. Either
 #' "past", "present", "singular" or "plural".
+#' @param seed a random seed to be used within the function only. Any existing
+#' seed in your R environment will be restored after the function is called.
+#' Default is NULL, which returns different results each time the function is
+#' called.
 #' @examples
-#' incdec(-1, "past")  # returns "decreased by"
+#' incdec(-1, "past", seed = 14)  # always returns "has fallen by"
+#' incdec(-1, "past") # returns one of "has fallen by", "is down by",
+#' "decreased by"
 #' @export
 #'
 
-incdec <- function(value, tense) {
+incdec <- function(value, tense, seed = NULL) {
 
   # Check input arguments
 
@@ -41,34 +48,41 @@ incdec <- function(value, tense) {
 
   value <- as.numeric(value) # converts strings into a number
 
+  # Save any existing random seed before we reset it within this function, then reapply the original seed on exit
+  old <- .Random.seed
+  on.exit( { .Random.seed <<- old } )
+
+  # Set new seed just for this function
+  set.seed(seed)
+
   if (tense == "present") {
     if (value > 0) {
-      "increasing by"
+      sample((c("up by", "rising by", "increasing by")), 1)
       }
     else if (value < 0) {
-      "decreasing by"
+      sample((c("falling by", "down by", "decreasing by")), 1)
       }
-    else stop("ERROR")
+    else ("remaining unchanged")
   }
 
   else if (tense == "past") {
     if (value > 0) {
-      "increased by"
+      sample((c("was up by", "has risen by", "increased by")), 1)
       }
     else if (value < 0) {
-      "decreased by"
+      sample((c("has fallen by", "is down by", "decreased by")), 1)
       }
     else ("was unchanged")
   }
 
   else if (tense == "singular") {
     if (value > 0) {
-      "increase"
+      sample((c("increase", "rise")), 1)
       }
     else if (value < 0) {
-      "decrease"
+      sample((c("fall", "drop", "decrease", "decline")), 1)
       }
-    else stop("ERROR")
+    else ("no change")
   }
 
   else if (tense == "plural") {
@@ -78,7 +92,7 @@ incdec <- function(value, tense) {
     else if (value < 0) {
       "decreases"
       }
-    else stop("ERROR")
+    else ("no changes")
   }
 
  }


### PR DESCRIPTION
Can't take credit for this suggestion, because someone who left our team implemented it in our own RAP. But basically the idea is to get `incdec()` to randomly choose from a set of phrases each time it is called, so that any text written with `incdec()` doesn't sound too repetitive.

To ensure reproducibility, I added a new argument, `seed`, which is a random seed used within the function only. Any existing
seed in your R environment will be restored after the function is called. Its default is NULL, which returns different results each time the function is called. But it can be set to a single number to guarantee it returns the same results every time.

For example, `incdec(-1, "past", seed = 14)` always returns "has fallen by". But `incdec(-1, "past")` can return any one of "has fallen by", "is down by",  or "decreased by".

I'm open to changing the default for `seed` to a single number which means the original phrases ( e.g. "increased by") are always used, thereby not affecting any team's existing code. But felt that this change at least shouldn't break any code if not.